### PR TITLE
use pathlib instead of os.path

### DIFF
--- a/iOS_Backup_UNF.py
+++ b/iOS_Backup_UNF.py
@@ -15,33 +15,35 @@ from io import BytesIO
 from dataclasses import dataclass
 from sys import exit
 from shutil import copyfile
+from pathlib import Path
 
 logging.basicConfig(format='%(asctime)s | %(levelname)s | %(message)s', level='DEBUG')
 
 # TODO: Add option to input a zipfile
 
+BACKUP_ROOT = Path("private") / "var"
 DOMAIN_TRANSLATION = {
-    "AppDomain": "private\\var\\mobile\\Containers\\Data\\Application",
-    "AppDomainGroup": "private\\var\\mobile\\Containers\\Shared\\AppGroup",
-    "AppDomainPlugin": "private\\var\\mobile\\Containers\\Data\\PluginKitPlugin",
-    "SysContainerDomain": "private\\var\\containers\\Data\\System",
-    "SysSharedContainerDomain": "private\\var\\containers\\Shared\\SystemGroup",
-    "KeychainDomain": "private\\var\\Keychains",
-    "CameraRollDomain": "private\\var\\mobile",
-    "MobileDeviceDomain": "private\\var\\MobileDevice",
-    "WirelessDomain": "private\\var\\wireless",
-    "InstallDomain": "private\\var\\installd",
-    "KeyboardDomain": "private\\var\\mobile",
-    "HomeDomain": "private\\var\\mobile",
-    "SystemPreferencesDomain": "private\\var\\preferences",
-    "DatabaseDomain": "private\\var\\db",
-    "TonesDomain": "private\\var\\mobile",
-    "RootDomain": "private\\var\\root",
-    "BooksDomain": "private\\var\\mobile\\Media\\Books",
-    "ManagedPreferencesDomain": "private\\var\\Managed Preferences",
-    "HomeKitDomain": "private\\var\\mobile",
-    "MediaDomain": "private\\var\\mobile",
-    "HealthDomain": "private\\var\\mobile\\Library"
+    "AppDomain": BACKUP_ROOT / "mobile" / "Containers" / "Data" / "Application",
+    "AppDomainGroup": BACKUP_ROOT / "mobile" / "Containers" / "Shared" / "AppGroup",
+    "AppDomainPlugin": BACKUP_ROOT / "mobile" / "Containers" / "Data" / "PluginKitPlugin",
+    "SysContainerDomain": BACKUP_ROOT / "containers" / "Data" / "System",
+    "SysSharedContainerDomain": BACKUP_ROOT / "containers" / "Shared" / "SystemGroup",
+    "KeychainDomain": BACKUP_ROOT / "Keychains",
+    "CameraRollDomain": BACKUP_ROOT / "mobile",
+    "MobileDeviceDomain": BACKUP_ROOT / "MobileDevice",
+    "WirelessDomain": BACKUP_ROOT / "wireless",
+    "InstallDomain": BACKUP_ROOT / "installd",
+    "KeyboardDomain": BACKUP_ROOT / "mobile",
+    "HomeDomain": BACKUP_ROOT / "mobile",
+    "SystemPreferencesDomain": BACKUP_ROOT / "preferences",
+    "DatabaseDomain": BACKUP_ROOT / "db",
+    "TonesDomain": BACKUP_ROOT / "mobile",
+    "RootDomain": BACKUP_ROOT / "root",
+    "BooksDomain": BACKUP_ROOT / "mobile" / "Media" / "Books",
+    "ManagedPreferencesDomain": BACKUP_ROOT / "Managed Preferences",
+    "HomeKitDomain": BACKUP_ROOT / "mobile",
+    "MediaDomain": BACKUP_ROOT / "mobile",
+    "HealthDomain": BACKUP_ROOT / "mobile" / "Library"
 }
 
 
@@ -63,13 +65,14 @@ class BackupFile:
             package_name = ""
 
         if domain in DOMAIN_TRANSLATION:
-            domain_subdir = os.path.join(DOMAIN_TRANSLATION[domain], package_name)
+            domain_subdir = DOMAIN_TRANSLATION[domain] / package_name
         else:
-            domain_subdir = os.path.join(domain, package_name)
+            domain_subdir = Path(domain) / package_name
 
-        true_path = os.path.join(domain_subdir, self.relative_path)
+        true_path = domain_subdir / self.relative_path
 
-        return os.path.normpath(true_path)
+        # normalize path and convert it back to Path(); did not found a better way
+        return Path(os.path.normpath(true_path))
 
     def get_mod_time(self):
         """
@@ -105,7 +108,7 @@ class BackupFile:
         :return:
         """
         zipinfo = zipfile.ZipInfo()
-        zipinfo.filename = self.translated_path()
+        zipinfo.filename = str(self.translated_path())
         zipinfo.date_time = self.get_mod_time()
         zipinfo.file_size = self.get_size()
         return zipinfo
@@ -117,7 +120,7 @@ def get_file_list(manifest_path):
     :param manifest_path: Path to the manifest.db file
     :return:
     """
-    mani_conn = sqlite3.connect(manifest_path)
+    mani_conn = sqlite3.connect(str(manifest_path))
     cur = mani_conn.cursor()
     logging.debug('Connected to manifest.db')
     sql = 'select fileID, domain, relativePath, file, flags from Files'
@@ -172,8 +175,8 @@ def process_into_zip(input_root, output_root, file_list):
     :param file_list:
     :return:
     """
-    output_path = os.path.join(output_root, "UNF_Backup.zip")
-    new_zip = zipfile.ZipFile(output_path, "w")
+    output_path = output_root / "UNF_Backup.zip"
+    new_zip = zipfile.ZipFile(str(output_path), "w")
     for backup_id, backup_file in file_list.items():
         if backup_file.is_dir is not True:
             zinfo = backup_file.get_zipinfo()
@@ -195,7 +198,7 @@ def create_directory(backup_file, output_root):
     """
     full_output_path = get_output_path(backup_file, output_root)
     # logging.debug(f"{full_output_path}")
-    os.makedirs(full_output_path, exist_ok=True)
+    full_output_path.mkdir(parents=True, exist_ok=True)
 
 
 def create_file(backup_file, input_root, output_root):
@@ -211,7 +214,7 @@ def create_file(backup_file, input_root, output_root):
         logging.warning(f"Missing file: {backup_file.file_id} ({backup_file.relative_path})")
         return 0
     output_path = get_output_path(backup_file, output_root)
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     copyfile(input_path, output_path)
 
 
@@ -223,15 +226,15 @@ def get_input_path(backup_file, input_root):
     :return:
     """
     # Case where backup files are in the same folder as manifest.db
-    full_input_path = os.path.join(input_root, backup_file.file_id)
-    if os.path.exists(full_input_path):
-        return os.path.normpath(full_input_path)
+    full_input_path = input_root / backup_file.file_id
+    if full_input_path.exists():
+        return full_input_path
 
     # Case where backup files exist in subdirectories
     sub_folder = backup_file.file_id[:2]
-    full_input_path = os.path.join(input_root, sub_folder, backup_file.file_id)
-    if os.path.exists(full_input_path):
-        return os.path.normpath(full_input_path)
+    full_input_path = input_root / sub_folder / backup_file.file_id
+    if full_input_path.exists():
+        return full_input_path
 
     # Otherwise we have no file!
     return None
@@ -245,8 +248,7 @@ def get_output_path(backup_file, output_root):
     :return:
     """
     dir_path = backup_file.translated_path()
-    full_output_path = os.path.join(output_root, dir_path)
-    return os.path.normpath(full_output_path)
+    return output_root / dir_path
 
 
 def get_file_data(backup_file, input_root):
@@ -260,7 +262,7 @@ def get_file_data(backup_file, input_root):
     if input_path is None:
         logging.warning(f"Missing file: {backup_file.file_id} ({backup_file.relative_path})")
         return None
-    file_data = open(input_path, 'rb').read()
+    file_data = open(str(input_path), 'rb').read()
 
     return file_data
 
@@ -274,24 +276,24 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Unpack iOS backups")
     parser.add_argument('-z', '--zip', dest='to_zip', default=False, action="store_true",
                         help='Output to zip')
-    parser.add_argument('-i', '--input', dest='input_dir', type=str, required=True, action='store',
+    parser.add_argument('-i', '--input', dest='input_dir', type=Path, required=True, action='store',
                         help='Input directory')
-    parser.add_argument('-o', '--output', dest='output_dir', type=str, default=".\\",
+    parser.add_argument('-o', '--output', dest='output_dir', type=Path, default=Path("."),
                         help='Output directory (default: current directory)')
 
     args = parser.parse_args()
 
-    input_dir = args.input_dir
-    output_dir = args.output_dir
+    input_dir = args.input_dir.resolve(strict=True)
+    output_dir = args.output_dir.resolve(strict=True)
     to_zip = args.to_zip
 
-    logging.info(f"Input Dir:  {input_dir}")
-    logging.info(f"Output Dir: {output_dir}")
+    logging.info(f"Input Dir:  {str(input_dir)}")
+    logging.info(f"Output Dir: {str(output_dir)}")
 
-    manifest_path = os.path.join(input_dir, 'manifest.db')
+    manifest_path = input_dir / 'manifest.db'
 
-    if os.path.exists(manifest_path) is not True:
-        logging.critical(f"Cannot find manifest.db at: {manifest_path}")
+    if not manifest_path.exists():
+        logging.critical(f"Cannot find manifest.db at: {str(manifest_path)}")
         logging.info("Exiting..")
         exit(1)
 


### PR DESCRIPTION
Hello,

it seems that this script was originally designed to be used on Windows (because of the `\\` paths).

So I replaced the usage of `os.path` with the `pathlib` library.

I tested it on Linux and Windows and it worked without problems.